### PR TITLE
Boutons de réponses sur plusieurs lignes

### DIFF
--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -165,7 +165,7 @@ class telegramCmd extends cmd {
 		if (isset($_options['answer'])) {
 			$data['disable_notification'] = 0;
 			$data['reply_markup'] = json_encode(array(
-				'keyboard' => array($_options['answer']),
+				'keyboard' => array_chunk ($_options['answer'],2),
 				'one_time_keyboard' => true,
 				'resize_keyboard' => true,
 			));


### PR DESCRIPTION
Lunarok,

Pour info, comme je propose dans le forum, il est possible d'afficher les boutons de réponses dans un clavier sur plusieurs lignes.
J'ai fait un premier test concluant avec pour la ligne 168 : 'keyboard' => array_chunk ($_options['answer'],2),
Juste une réserve, j'ai reçu un log d'erreur mais je ne saurais pas dire si c'est dû à cette modif ou si c'est une erreur sur une modif précédente dans mes tests.. A voir dans la durée.

A voir si c'est intéressant à ajouter (valeur par défaut ou paramétrable). Je te laisse en faire ce que tu veux ;)