### PR TITLE
Ajout d'une option "user" à la commande "Tous"

### DIFF
--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -158,6 +158,14 @@ class telegramCmd extends cmd {
                     }
                 }
             }
+            elseif(isset($options['chatId'])) {
+                foreach ($eqLogic->getCmd('action') as $cmd) {
+                    if ($cmd->getLogicalId() === $options['chatId']) {
+                        $to[] = $cmd->getConfiguration('chatid');
+                        break;
+                    }
+                }
+            }
             else {
                 foreach ($eqLogic->getCmd('action') as $cmd) {
                     if ($cmd->getLogicalId() != 'alluser') {

--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -150,14 +150,24 @@ class telegramCmd extends cmd {
 		$eqLogic = $this->getEqLogic();
 		$to = array();
 		if ($this->getLogicalId() == 'alluser') {
-			foreach ($eqLogic->getCmd('action') as $cmd) {
-				if ($cmd->getLogicalId() != 'alluser') {
-					$to[] = $cmd->getConfiguration('chatid');
-				}
-			}
+            if(isset($options['user'])) {
+                foreach ($eqLogic->getCmd('action') as $cmd) {
+                    if ($cmd->getName() === $options['user']) {
+                        $to[] = $cmd->getConfiguration('chatid');
+                        break;
+                    }
+                }
+            }
+            else {
+                foreach ($eqLogic->getCmd('action') as $cmd) {
+                    if ($cmd->getLogicalId() != 'alluser') {
+                        $to[] = $cmd->getConfiguration('chatid');
+                    }
+                }
+            }
 		} else {
 			$to[] = $this->getConfiguration('chatid');
-		}
+        }
 		$request_http = "https://api.telegram.org/bot" . trim($eqLogic->getConfiguration('bot_token'));
 		$data['disable_notification'] = (isset($options['disable_notify'])) ? $options['disable_notify'] : $eqLogic->getConfiguration('disable_notify', 0);
 		$data['parse_mode'] = (isset($options['parse_mode'])) ? $options['parse_mode'] : $eqLogic->getConfiguration('parse_mode', 'HTML');


### PR DESCRIPTION
Bonjour @lunarok ,

Merci pour ce plugin qui fonctionne très bien, cependant je suis confronté à un problème et comme je pense ne pas être le seul je fais cette pull request:  envoyer un message à un destinataire récupéré dans une variable/tag.

Dans mon cas d'utilisation, j'ai des scénarios qui exécutent plusieurs commandes Ask via Telegram les unes à la suite des autres (exemple: "Ouvrir les volets ?", "Allumer la radio ?", etc).
Ne sachant qui va répondre, j'envoie évidemment sur "Tous". Une fois que quelqu'un à répondu, il est possible de savoir à qui envoyer les autres questions puisqu'il suffit de récupérer cette information via la commande "Expéditeur", sauf qu'il est impossible dans l'éditeur de scénario de Jeedom d'utiliser cette information pour cibler le destinataire.

J'ai donc ajouté une option "user" dans la commande "Tous" qui permet de cibler un utilisateur en particulier.
Cette option prend en paramètre le nom de la commande liée à l'utilisateur. Evidemment on peut y ajouter les autres options habituelles (comme parse).

Comme des images valent mieux que mille mots, voici des captures du fonctionnement:
![Commande liée à l'utilisateur](https://user-images.githubusercontent.com/7091140/86532734-75f7c780-becc-11ea-982e-1f2e1730fa8e.png)
![Utilisation dans un scénario](https://user-images.githubusercontent.com/7091140/86532740-7e500280-becc-11ea-9483-7bf110765d9e.png)

Je pense que cette fonction serait certainement très utile. Je n'ai pas trouvé d'autre moyen de la mettre en place mais je pense cependant que cette solution n'est pas mauvaise et est facile à utiliser.

Merci de bien vouloir jeter un œil dessus (ça ne représente qu'une dizaine de lignes de codes) :)