### PR TITLE
Ajouter d'une commande info avec l'identité de l'expéditeur d'un ASK Telegram

### DIFF
--- a/core/api/jeeTelegram.php
+++ b/core/api/jeeTelegram.php
@@ -47,6 +47,7 @@ if (isset($json["message"]["text"])) {
 	foreach ($eqLogic->getCmd('action') as $cmd) {
 		if ($cmd->askResponse($json["message"]["text"])) {
 			echo json_encode(array('text' => ''));
+			$eqLogic->checkAndUpdateCmd('ask_sender', trim($json["message"]["from"]["id"]));
 			die();
 		}
 	}

--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -60,6 +60,18 @@ class telegram extends eqLogic {
 		$sender->setSubType('string');
 		$sender->setEqLogic_id($this->getId());
 		$sender->save();
+		
+		$ask_sender = $this->getCmd(null, 'ask_sender');
+                if (!is_object($ask_sender)) {
+                        $ask_sender = new telegramCmd();
+                        $ask_sender->setLogicalId('ask_sender');
+                        $ask_sender->setIsVisible(0);
+                        $ask_sender->setName(__('Dernier expediteur ASK', __FILE__));
+                }
+                $ask_sender->setType('info');
+                $ask_sender->setSubType('string');
+                $ask_sender->setEqLogic_id($this->getId());
+                $ask_sender->save();
 
 		$sender = $this->getCmd(null, 'chat');
 		if (!is_object($sender)) {

--- a/core/i18n/fr_FR.json
+++ b/core/i18n/fr_FR.json
@@ -30,7 +30,8 @@
     },
     "plugins\/telegram\/core\/class\/telegram.class.php": {
         "Message": "Message",
-        "Expediteur": "Expediteur",
+        "Expediteur": "Expediteur",        
+        "Dernier expediteur ASK": "Dernier expediteur ASK",
         "Tous": "Tous"
     }
 }


### PR DESCRIPTION
Afin de pouvoir personnaliser les réponses dans les scénarios, j'ai ajouté la commande info qui reprend le dernier expéditeur d'un ASK Telegram.