### PR TITLE
Ajout de cmd actions Last User

### DIFF
--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -85,6 +85,23 @@ class telegram extends eqLogic {
 		$sender->setEqLogic_id($this->getId());
 		$sender->save();
 
+		$cmd = $this->getCmd(null, 'lastaskuser');
+                if (!is_object($cmd)) {
+                        $cmd = new telegramCmd();
+                        $cmd->setLogicalId('lastaskuser');
+                        $cmd->setIsVisible(1);
+                        $cmd->setName(__('Dernier utilisateur ASK', __FILE__));
+                        $cmd->setType('action');
+                        $cmd->setConfiguration('chatid', 'Dernier utilisateur ASK');
+                        $cmd->setConfiguration('firstname', 'Dernier utilisateur ASK');
+                        $cmd->setConfiguration('username', 'Dernier utilisateur ASK');
+                        $cmd->setSubType('message');
+                        $cmd->setEqLogic_id($this->getId());
+                        $cmd->setDisplay('title_placeholder', __('Options', __FILE__));
+                        $cmd->setDisplay('message_placeholder', __('Message', __FILE__));
+                        $cmd->save();
+                }
+		
 		$cmd = $this->getCmd(null, 'alluser');
 		if (!is_object($cmd)) {
 			$cmd = new telegramCmd();
@@ -168,7 +185,9 @@ class telegramCmd extends cmd {
 					$to[] = $cmd->getConfiguration('chatid');
 				}
 			}
-		} else {
+		} elseif ($this->getLogicalId() == 'lastaskuser') {
+                        $to[] = $eqLogic->getCmd(null, 'ask_sender')->execCmd();
+                } else {
 			$to[] = $this->getConfiguration('chatid');
 		}
 		$request_http = "https://api.telegram.org/bot" . trim($eqLogic->getConfiguration('bot_token'));

--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -83,7 +83,7 @@ class telegram extends eqLogic {
 		$sender->setType('info');
 		$sender->setSubType('string');
 		$sender->setEqLogic_id($this->getId());
-		$sender->save();
+		$sender->save();		
 
 		$cmd = $this->getCmd(null, 'lastaskuser');
                 if (!is_object($cmd)) {
@@ -95,6 +95,23 @@ class telegram extends eqLogic {
                         $cmd->setConfiguration('chatid', 'Dernier utilisateur ASK');
                         $cmd->setConfiguration('firstname', 'Dernier utilisateur ASK');
                         $cmd->setConfiguration('username', 'Dernier utilisateur ASK');
+                        $cmd->setSubType('message');
+                        $cmd->setEqLogic_id($this->getId());
+                        $cmd->setDisplay('title_placeholder', __('Options', __FILE__));
+                        $cmd->setDisplay('message_placeholder', __('Message', __FILE__));
+                        $cmd->save();
+                }
+
+                $cmd = $this->getCmd(null, 'lastuser');
+                if (!is_object($cmd)) {
+                        $cmd = new telegramCmd();
+                        $cmd->setLogicalId('lastuser');
+                        $cmd->setIsVisible(1);
+                        $cmd->setName(__('Dernier utilisateur', __FILE__));
+                        $cmd->setType('action');
+                        $cmd->setConfiguration('chatid', 'Dernier utilisateur');
+                        $cmd->setConfiguration('firstname', 'Dernier utilisateur');
+                        $cmd->setConfiguration('username', 'Dernier utilisateur');
                         $cmd->setSubType('message');
                         $cmd->setEqLogic_id($this->getId());
                         $cmd->setDisplay('title_placeholder', __('Options', __FILE__));
@@ -181,12 +198,14 @@ class telegramCmd extends cmd {
 		$to = array();
 		if ($this->getLogicalId() == 'alluser') {
 			foreach ($eqLogic->getCmd('action') as $cmd) {
-				if ($cmd->getLogicalId() != 'alluser') {
+				if (!in_array($cmd->getLogicalId(), ['alluser','lastaskuser','lastuser'])) {
 					$to[] = $cmd->getConfiguration('chatid');
 				}
 			}
 		} elseif ($this->getLogicalId() == 'lastaskuser') {
                         $to[] = $eqLogic->getCmd(null, 'ask_sender')->execCmd();
+		} elseif ($this->getLogicalId() == 'lastuser') {
+                        $to[] = $eqLogic->getCmd(null, 'sender')->execCmd();
                 } else {
 			$to[] = $this->getConfiguration('chatid');
 		}

--- a/core/i18n/fr_FR.json
+++ b/core/i18n/fr_FR.json
@@ -32,6 +32,8 @@
         "Message": "Message",
         "Expediteur": "Expediteur",        
         "Dernier expediteur ASK": "Dernier expediteur ASK",
+        "Dernier utilisateur ASK": "Dernier utilisateur ASK",
+        "Dernier utilisateur": "Dernier utilisateur",
         "Tous": "Tous"
     }
 }


### PR DESCRIPTION
- Ajout d'une commande action "Dernier utilisateur" qui permet l'envoi d'un Telegram uniquement au dernier utilisateur ayant discuté avec Jeedom (hors fonction ASK)
Par exemple, si un utilisateur déclenche un scénario en envoyant un Telegram, on peut lui répondre directement sans aucun calcul et bloc code.
- Ajout d'une commande action "Dernier utilisateur ASK" qui permet l'envoi d'un Telegram uniquement au dernier utilisateur ayant discuté avec Jeedom avec la fonction ASK.
Pour des ASK en cascade par exemple, cela permet de ne répondre qu'à l'expéditeur du ASK précédent.

Cela évite la création d'un scénario pour récupérer l'information et construire l'appel.