### PR TITLE
Possibilité de passer des options à curl

### DIFF
--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -306,7 +306,7 @@ class telegramCmd extends cmd {
 			unset($data['snapshot']);
 			$save = '/tmp/telegram_' . $this->getId() . '.png';
 			unlink($save);
-			$cmd = 'curl ' . $options['snapshot'] . ' -o ' . $save;
+			$cmd = 'curl ' . (isset($options['curl_opts']) ? trim($options['curl_opts'], "\"") : '') . ' ' . $options['snapshot'] . ' -o ' . $save;
 			shell_exec($cmd);
 			$_options['files'][] = $save;
 		}


### PR DESCRIPTION
Permet d'ajouter des options à la commande curl lors de la récupération d'un snapshot.

Exemple pour le champs Options lors de l'envoi d'un message :

curl_opts="-u 'user:password'" snapshot="http://camera/tmpfs/auto.jpg"
curl_opts="-H 'Authorization: Basic dXNlcjpwYXNzd29yZA'" snapshot="http://camera/tmpfs/auto.jpg"