### PR TITLE
'hide_keyboard' a été renommé 'remove_keyboard'

### DIFF
--- a/core/class/telegram.class.php
+++ b/core/class/telegram.class.php
@@ -251,7 +251,7 @@ class telegramCmd extends cmd {
 				$data['text'] = $_options['message'];
 			}
 			$data['reply_markup'] = json_encode(array(
-				'hide_keyboard' => true,
+				'remove_keyboard' => true,
 			));
 			$url = $request_http . "/sendMessage";
 			$this->sendTelegram($url, 'message', $to, $data);


### PR DESCRIPTION
Il y a 5 ans Telegram a renommé 'hide_keyboard' pour 'remove_keyboard' : https://core.telegram.org/bots/api-changelog#november-21-2016

La rétrocompatibilité est assurée, du moins jusque là, tant mieux.

Testé Ok chez moi, le comportement est strictement le même.